### PR TITLE
SpaceChem support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,17 @@ sdl1-hooks-i686.so: sdl1-hooks.c
 	gcc -m32 -march=i686 -shared -fPIC -g -o $@ $< -ldl
 	$(STRIP) $@
 
+# SDL 1.2 PeepEvent
+AMD64_LIBS += sdl1-peep-hooks-amd64.so
+sdl1-peep-hooks-amd64.so: sdl1-peep-hooks.c
+	gcc -m64 -march=k8 -shared -fPIC -g -o $@ $< -ldl
+	$(STRIP) $@
+
+I686_LIBS += sdl1-peep-hooks-i686.so
+sdl1-peep-hooks-i686.so: sdl1-peep-hooks.c
+	gcc -m32 -march=i686 -shared -fPIC -g -o $@ $< -ldl
+	$(STRIP) $@
+
 # SDL 2.0
 AMD64_LIBS += sdl2-hooks-amd64.so
 sdl2-hooks-amd64.so: sdl2-hooks.c

--- a/games/README.md
+++ b/games/README.md
@@ -10,4 +10,5 @@ Game                                      | Library | Linux              | OSX
 [Multiwinia](./multiwinia.md)             | SDL 1.2 | :heavy_check_mark: | :no_entry_sign:
 [Prison Architect](./prison_architect.md) | SDL 2.0 | :heavy_check_mark: | :heavy_check_mark:
 [SUPERHOT](./superhot.md)                 | xlib    | :heavy_check_mark: | :no_entry_sign:
+[SpaceChem](./spacechem.md)               | SDL 1.2 | :heavy_check_mark: | :no_entry_sign:
 

--- a/games/README.md
+++ b/games/README.md
@@ -9,6 +9,5 @@ Game                                      | Library | Linux              | OSX
 [Factorio](./factorio.md)                 | xlib    | :heavy_check_mark: | :no_entry_sign:
 [Multiwinia](./multiwinia.md)             | SDL 1.2 | :heavy_check_mark: | :no_entry_sign:
 [Prison Architect](./prison_architect.md) | SDL 2.0 | :heavy_check_mark: | :heavy_check_mark:
+[SpaceChem](./spacechem.md)               | SDL 1.2 (peep) | :heavy_check_mark: | :no_entry_sign:
 [SUPERHOT](./superhot.md)                 | xlib    | :heavy_check_mark: | :no_entry_sign:
-[SpaceChem](./spacechem.md)               | SDL 1.2 | :heavy_check_mark: | :no_entry_sign:
-

--- a/games/spacechem.md
+++ b/games/spacechem.md
@@ -1,0 +1,22 @@
+# SpaceChem
+
+## Linux
+
+Copy the compiled `sdl1-peep-hooks-i686.so` (even if you are on `amd64` -- there is no native binary on the Steam version) into `SteamLibrary/SteamApps/common/SpaceChem`.
+
+Modify ``spacechem-launcher.sh`` file from:
+
+```
+#!/bin/sh
+MONO_CFG_DIR=etc MONO_PATH=monolib ./mono SpaceChem.exe
+```
+
+To 
+
+```
+#!/bin/sh
+LD_PRELOAD="${LD_PRELOAD}:./sdl1-peep-hooks-i686.so" MONO_CFG_DIR=etc MONO_PATH=monolib ./mono SpaceChem.exe
+```
+
+Then run SpaceChem through Steam as normal.
+

--- a/sdl1-peep-hooks.c
+++ b/sdl1-peep-hooks.c
@@ -1,0 +1,60 @@
+/* -*- mode: c; indent-tabs-mode: nil; tab-width: 2
+  sdl-fakeqwerty/sdl1-hooks.c
+  Copyright 2017 Michael Farrell <micolous+git@gmail.com>
+ 
+  Hook some SDL1.2 related input functionality and make it look like there is a
+  QWERTY keyboard attached for applications which read the "sym" (SDL_Keycode).
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#define _GNU_SOURCE
+#include <SDL/SDL_events.h>
+#include "helper.h"
+
+const char* qwerty_syms = "1234567890-=\0\0qwertyuiop[]\0\0asdfghjkl;'`\0\\zxcvbnm,./";
+
+
+typedef int (*sig_SDL_PeepEvents)(SDL_Event* event, int numevents, SDL_eventaction action,
+                                                                Uint32 mask);
+
+int SDL_PeepEvents(SDL_Event *events, int numevents, SDL_eventaction action,
+                                                                Uint32 mask)
+{
+  int i;
+  SDL_Event* event;
+  GET_ORIG(SDL_PeepEvents);
+
+  int ret = orig_SDL_PeepEvents(events, numevents, action, mask);
+  // There are events which we should try to mangle.
+  if (ret > 0) {
+    for (int i = 0; i < ret; i++) {
+      event = &events[i];
+      if (event->type == SDL_KEYDOWN || event->type == SDL_KEYUP) {
+
+        if (event->key.keysym.scancode >= 0x0A && event->key.keysym.scancode <= 0x3d) {
+          uint16_t new_sym = (uint8_t)qwerty_syms[event->key.keysym.scancode - 0x0a];
+
+          if (new_sym != 0) {
+            event->key.keysym.sym = new_sym;
+          }
+        }
+
+      }
+    }
+  }
+  return ret;
+}
+


### PR DESCRIPTION
Hi,

This is a proposal to integrate SpaceChem support to your library. Some explanations about why current implementation does not handle SpaceChem, and how it is fixed by this proposal can be found below.

Are you willing to integrate SpaceChem support ?

---

SpaceChem uses SDL through a mono binding; as mono perform its own
binding of SDL_PollEvent function, LD_PRELOAD fails (as mono performs
its own lookup directly in libSDL-1.2.so, and don't call the preloaded
version).

Proposed fix adds a new preload sdl1-peep-hooks.c file that overrides
SDL_PeepEvents in place of SDL_PollEvent. As this function is not
directly called from mono, LD_PRELOAD mechanism is honored.

This fix is known to work with a SpaceChem Steam version at this date.

Makefile is modified, to produce sdl1-peep-hooks-{amd64,i686}.so files.

Installation instruction: perform a build, put file in the SpaceChem
folder and modify spacechem-launcher.sh:

``` sh
LD_PRELOAD="${LD_PRELOAD}:./sdl1-peep-hooks-i686.so" MONO_CFG_DIR=etc MONO_PATH=monolib ./mono SpaceChem.exe
```